### PR TITLE
Fix mutability of objects

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::collections::HashMap;
 use std::cell::RefCell;
+use std::borrow::BorrowMut;
 
 use constants::{CHANGED_KEY,NEW_KEY,STAGED_KEY,CONFLICTS_KEY};
 
@@ -95,7 +96,7 @@ impl Cache {
         self.file_statuses.borrow().is_some()
     }
 
-    fn get_file_statuses(&self) -> Option<HashMap<String, u32>> {
+    fn get_file_statuses(&mut self) -> Option<HashMap<String, u32>> {
         self.file_statuses.borrow().clone()
     }
 }
@@ -345,7 +346,7 @@ impl Backend {
         }
     }
 
-    pub fn get_file_status(&self) -> Option<HashMap<String, u32>> {
+    pub fn get_file_status(&mut self) -> Option<HashMap<String, u32>> {
         if self.cache.is_file_statuses_set() {
             return self.cache.get_file_statuses();
         }
@@ -384,15 +385,14 @@ impl Backend {
         Some(d)
     }
 
-    pub fn get_stash_count(&self) -> u16 {
-        let mut count: RefCell<u16> = RefCell::new(0);
-        self.repo.borrow_mut().stash_foreach(
+    pub fn get_stash_count(&mut self) -> u16 {
+        let mut count: u16 = 0;
+        self.repo.stash_foreach(
             |u: usize, s: &str, o: &Oid| {
-                let mut c = count.borrow_mut();
-                *c += 1;
+                count += 1;
                 true
             }
         );
-        count.into_inner()
+        count
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -83,18 +83,18 @@ impl<'a> RepoStatus<'a> {
 #[derive(Debug)]
 pub struct StashStatus<'a> {
     debug: bool,
-    backend: &'a Backend,
+    backend: &'a mut Backend,
     value: SimpleValue,
 }
 
 impl<'a> StashStatus<'a> {
-    fn new(simple_value: &SimpleValue, backend: &'a Backend, debug: bool) -> StashStatus<'a> {
+    fn new(simple_value: &SimpleValue, backend: &'a mut Backend, debug: bool) -> StashStatus<'a> {
         StashStatus{
             value: simple_value.clone(), backend: backend, debug: debug
         }
     }
 
-    fn display(&self) -> Option<String> {
+    fn display(&mut self) -> Option<String> {
         log!(self, "display repository state, value: {:?}", self);
         let count = self.backend.get_stash_count();
         if count > 0 {
@@ -110,13 +110,13 @@ impl<'a> StashStatus<'a> {
 #[derive(Debug)]
 pub struct FileStatus<'a> {
     debug: bool,
-    backend: &'a Backend,
+    backend: &'a mut Backend,
     value: SimpleValue,
 }
 
 impl<'a> FileStatus<'a> {
     // get # of files for specific type
-    fn get_file_status_for_type(&self, file_type: &str) -> Option<u32> {
+    fn get_file_status_for_type(&mut self, file_type: &str) -> Option<u32> {
         let mut h: HashMap<String, &str> = HashMap::new();
         h.insert("new".to_string(), NEW_KEY);
         h.insert("changed".to_string(), CHANGED_KEY);
@@ -135,15 +135,16 @@ impl<'a> FileStatus<'a> {
         None
     }
 
-    fn new(simple_value: &SimpleValue, backend: &'a Backend, debug: bool) -> FileStatus<'a> {
+    fn new(simple_value: &SimpleValue, backend: &'a mut Backend, debug: bool) -> FileStatus<'a> {
         FileStatus{
             value: simple_value.clone(), backend: backend, debug: debug
         }
     }
 
-    fn display(&self) -> Option<String> {
+    fn display(&mut self) -> Option<String> {
         log!(self, "display file state, value: {:?}", self);
-        if let Some(x) = self.get_file_status_for_type(&self.value.value_type) {
+        let vt = self.value.value_type.clone();
+        if let Some(x) = self.get_file_status_for_type(&vt) {
             return Some(format_value(&self.value.pre_format,
                                      &self.value.post_format,
                                      &format!("{}", x)));
@@ -296,16 +297,16 @@ impl DisplayMaster {
         DisplayMaster { backend: backend, debug: debug }
     }
 
-    pub fn display_value(&self, value_yaml: &Yaml, simple_value: &SimpleValue) -> Option<String> {
+    pub fn display_value(&mut self, value_yaml: &Yaml, simple_value: &SimpleValue) -> Option<String> {
         let o: Option<String> = match simple_value.value_type.as_str() {
             "repository_state" => RepoStatus::new(simple_value, &self.backend, self.debug).display(),
             "new" |
             "changed" |
             "staged" |
-            "conflicts" => FileStatus::new(simple_value, &self.backend, self.debug).display(),
+            "conflicts" => FileStatus::new(simple_value, &mut self.backend, self.debug).display(),
             // separator is displayed in conf, pretty hacky
             // "separator" => Separator::new(&simple_value, self.debug).display(),
-            "stash" => StashStatus::new(simple_value, &self.backend, self.debug).display(),
+            "stash" => StashStatus::new(simple_value, &mut self.backend, self.debug).display(),
             "remote_difference" => RemoteTracking::new(value_yaml, simple_value, &self.backend, self.debug).display(),
             _ => {
                 // let's ignore these values


### PR DESCRIPTION
The `stash_foreach` operation on git repo, for reasons unknown, operates
on non-const pointer in the underlying C libgit2 bindings, so we need
to pass mutable reference around - even though it looks ugly, it works.

(Using `RefCell<Backend>` is probably *the* right way to do this I'll check it out this evening)