### PR TITLE
update git2 to v0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ default-features = false
 features = ["std", "cargo"]
 
 [dependencies.git2]
-version = "0.14.*"
+version = "0.18"
 default-features = false
 features = []


### PR DESCRIPTION
Version 0.14 of the git2 crate pulls in libgit2 1.4.5, which was released two years ago, and the 1.4 branch has been out of support for almost that long.

There have been multiple security issues with libgit2 in recent years, most recently, two medium/high severity CVE issues that were only fixed on the 1.7 and 1.6 branches of libgit2. However, only the v0.18 branch of the git2 crate was updated for the latest security fixes, so v0.18 is the only version of the git2 crate that is not vulnerable to any currently known security issues.